### PR TITLE
Mod-controlled quotes feature

### DIFF
--- a/KruBot/KruBot.csproj
+++ b/KruBot/KruBot.csproj
@@ -260,6 +260,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Quote.cs" />
     <EmbeddedResource Include="frmCredentials.resx">
       <DependentUpon>frmCredentials.cs</DependentUpon>
     </EmbeddedResource>

--- a/KruBot/Quote.cs
+++ b/KruBot/Quote.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KruBot
+{
+    class Quote
+    {
+        public string command;
+        public string quoteText;
+
+        public Quote()
+        {
+            command = "";
+            quoteText = "";
+        }
+
+        public Quote(string passedCommand, string passedText)
+        {
+            command = passedCommand;
+            quoteText = passedText;
+        }
+    }
+}

--- a/KruBot/frmKruBot.cs
+++ b/KruBot/frmKruBot.cs
@@ -379,7 +379,7 @@ namespace KruBot
             }
 
             // Mod only commands
-            if (e.ChatMessage.UserType == TwitchLib.Client.Enums.UserType.Moderator)
+            if (e.ChatMessage.UserType == TwitchLib.Client.Enums.UserType.Moderator || e.ChatMessage.UserType == TwitchLib.Client.Enums.UserType.Broadcaster)
             {
                 if (e.ChatMessage.Message.ToUpper().StartsWith("!NEWQUOTE"))
                 {


### PR DESCRIPTION
Mods can !NEWQUOTE in the format of "!NEWQUOTE !COMMAND Quote text goes here" and also !DELETEQUOTE in the format "!DELETEQUOTE !COMMAND".

Any user can call a quote by typing !COMMAND. This can be changed in the future to give the streamer more options, like using currency or checking if the user is subbed. Quote commands and text are saved to quotes.json. It's deserialized when the main form is loaded and serialized whenever !NEWQUOTE or !DELETEQUOTE is called.